### PR TITLE
Multiple language support

### DIFF
--- a/app/src/main/java/com/vlath/keyboard/LatinKeyboard.java
+++ b/app/src/main/java/com/vlath/keyboard/LatinKeyboard.java
@@ -32,7 +32,7 @@ public class LatinKeyboard extends Keyboard {
 
     static final int KEYCODE_ALT  = -114;
 
-    static final int KEYCODE_QWERTY_SWITCH = -117;
+    static final int KEYCODE_STANDARD_SWITCH = -117;
 
     static final int KEYCODE_DELL_PROCESS = -121;
 

--- a/app/src/main/java/com/vlath/keyboard/PCKeyboard.java
+++ b/app/src/main/java/com/vlath/keyboard/PCKeyboard.java
@@ -131,7 +131,7 @@ public class PCKeyboard extends InputMethodService
 
     private LatinKeyboard mSymbolsKeyboard;
     private LatinKeyboard mSymbolsShiftedKeyboard;
-    private LatinKeyboard mQwertyKeyboard;
+    private LatinKeyboard mStandardKeyboard;
 
 
 
@@ -154,9 +154,9 @@ public class PCKeyboard extends InputMethodService
 
     private LatinKeyboard currentKeyboard;
     private LatinKeyboard mCurKeyboard;
-    private LatinKeyboard qwertyKeyboard;
+    private LatinKeyboard standardKeyboard;
 
-    private int qwertyKeyboardID = R.xml.qwerty;
+    private int standardKeyboardID = R.xml.qwerty;
     /**
      * Main initialization of the input method component. Be sure to call
      * to super class.
@@ -176,7 +176,7 @@ public class PCKeyboard extends InputMethodService
      * is called after creation and any configuration change.
      */
     @Override public void onInitializeInterface() {
-        if (mQwertyKeyboard != null) {
+        if (mStandardKeyboard != null) {
             // Configuration changes can happen after the keyboard gets recreated,
             // so we need to be able to re-build the keyboards if the available
             // space has changed.
@@ -184,7 +184,7 @@ public class PCKeyboard extends InputMethodService
             if (displayWidth == mLastDisplayWidth) return;
             mLastDisplayWidth = displayWidth;
         }
-        mQwertyKeyboard = new LatinKeyboard(this, qwertyKeyboardID);
+        mStandardKeyboard = new LatinKeyboard(this, standardKeyboardID);
         mSymbolsKeyboard = new LatinKeyboard(this, R.xml.symbols);
         mSymbolsShiftedKeyboard = new LatinKeyboard(this, R.xml.symbols2);
     }
@@ -202,7 +202,7 @@ public class PCKeyboard extends InputMethodService
                 R.layout.keyboard, null);
         mInputView.setOnKeyboardActionListener(this);
         mInputView.setPreviewEnabled(false);
-        setLatinKeyboard(mQwertyKeyboard);
+        setLatinKeyboard(mStandardKeyboard);
         return mInputView;
     }
 
@@ -262,7 +262,7 @@ public class PCKeyboard extends InputMethodService
         else {
             kv = (CustomKeyboard) getLayoutInflater().inflate(R.layout.keyboard, null);
         }
-        setQwertyKeyboard();
+        setStandardKeyboard();
         setInputType();
         Paint mPaint = new Paint();
         ColorMatrixColorFilter filterInvert = new ColorMatrixColorFilter(mDefaultFilter);
@@ -307,7 +307,7 @@ public class PCKeyboard extends InputMethodService
         // its window.
         setCandidatesViewShown(false);
 
-        mCurKeyboard = mQwertyKeyboard;
+        mCurKeyboard = mStandardKeyboard;
         if (mInputView != null) {
             mInputView.closing();
         }
@@ -431,7 +431,7 @@ public class PCKeyboard extends InputMethodService
      */
     private void updateShiftKeyState(EditorInfo attr) {
         if (attr != null
-                && mInputView != null && mQwertyKeyboard == mInputView.getKeyboard()) {
+                && mInputView != null && mStandardKeyboard == mInputView.getKeyboard()) {
             int caps = 0;
             EditorInfo ei = getCurrentInputEditorInfo();
             if (ei != null && ei.inputType != InputType.TYPE_NULL) {
@@ -908,7 +908,7 @@ public class PCKeyboard extends InputMethodService
     private void setInputType() {
 
         /** Checks the preferences for the default keyboard layout.
-         * If qwerty, we start out whether in qwerty or numbers, depending on the input type.
+         * If standard, we start out whether in standard or numbers, depending on the input type.
          * */
 
         EditorInfo attribute = getCurrentInputEditorInfo();
@@ -927,15 +927,15 @@ public class PCKeyboard extends InputMethodService
                             webInputType == InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT ||
                             webInputType == InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
                             || webInputType == InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS) {
-                        currentKeyboard = new LatinKeyboard(this, qwertyKeyboardID);
+                        currentKeyboard = new LatinKeyboard(this, standardKeyboardID);
                     } else {
-                        currentKeyboard = new LatinKeyboard(this, qwertyKeyboardID);
+                        currentKeyboard = new LatinKeyboard(this, standardKeyboardID);
                     }
 
                     break;
 
                 default:
-                    currentKeyboard = new LatinKeyboard(this, qwertyKeyboardID);
+                    currentKeyboard = new LatinKeyboard(this, standardKeyboardID);
                     break;
             }
         } else {
@@ -948,7 +948,7 @@ public class PCKeyboard extends InputMethodService
     public void setDefaultKeyboard() {
         switch (PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getString("start", "1")) {
             case "1":
-                currentKeyboard = qwertyKeyboard;
+                currentKeyboard = standardKeyboard;
                 break;
             case "2":
                 currentKeyboard = new LatinKeyboard(this, R.xml.arrow_keys);
@@ -1074,7 +1074,7 @@ public class PCKeyboard extends InputMethodService
                 break;
             case Keyboard.KEYCODE_MODE_CHANGE:
 
-                /** Switch between qwerty/symbols layout. */
+                /** Switch between standard/symbols layout. */
 
                 if (!isSysmbols) {
                     isSysmbols = !isSysmbols;
@@ -1082,7 +1082,7 @@ public class PCKeyboard extends InputMethodService
                     kv.setKeyboard(currentKeyboard);
                 } else {
                     isSysmbols = false;
-                    currentKeyboard = new LatinKeyboard(this, qwertyKeyboardID);
+                    currentKeyboard = new LatinKeyboard(this, standardKeyboardID);
                     kv.setKeyboard(currentKeyboard);
                 }
                 kv.getLatinKeyboard().changeKeyHeight(getHeightKeyModifier());
@@ -1091,13 +1091,13 @@ public class PCKeyboard extends InputMethodService
             case LatinKeyboard.KEYCODE_LAYUOUT_SWITCH:
 
                 /** Language Switch is a custom value defined in the LatinKeyboard class.
-                 * We use it to switch between qwerty/arrow keys/programming layouts. */
+                 * We use it to switch between standard/arrow keys/programming layouts. */
 
                 if (isDpad || isProgramming) {
                     if (isProgramming) {
-                        currentKeyboard = new LatinKeyboard(this, qwertyKeyboardID);
+                        currentKeyboard = new LatinKeyboard(this, standardKeyboardID);
                         kv.invalidateAllKeys();
-                        currentKeyboard.setRowNumber(getQwertyRowNumber());
+                        currentKeyboard.setRowNumber(getStandardRowNumber());
                         kv.setKeyboard(currentKeyboard);
                         isProgramming = false;
                         isDpad = false;
@@ -1184,12 +1184,12 @@ public class PCKeyboard extends InputMethodService
                     kv.draw(new Canvas());
                 }
                 break;
-            case LatinKeyboard.KEYCODE_QWERTY_SWITCH:
+            case LatinKeyboard.KEYCODE_STANDARD_SWITCH:
 
-                /** This key enables the user to switch rapidly between qwerty/arrow keys layouts.*/
+                /** This key enables the user to switch rapidly between standard/arrow keys layouts.*/
 
-                currentKeyboard = new LatinKeyboard(getBaseContext(), qwertyKeyboardID);
-                currentKeyboard.setRowNumber(getQwertyRowNumber());
+                currentKeyboard = new LatinKeyboard(getBaseContext(), standardKeyboardID);
+                currentKeyboard.setRowNumber(getStandardRowNumber());
                 kv.setKeyboard(currentKeyboard);
                 kv.getLatinKeyboard().changeKeyHeight(getHeightKeyModifier());
                 isDpad = false;
@@ -1263,7 +1263,7 @@ public class PCKeyboard extends InputMethodService
 
         rowNumber = (short) number;
     }
-    public short getQwertyRowNumber(){
+    public short getStandardRowNumber(){
 
         if(PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("arr_qrt", false) && PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("nbr_qrt", false)){
             return 5;
@@ -1281,22 +1281,49 @@ public class PCKeyboard extends InputMethodService
         }
 
     }
-    public void setQwertyKeyboard(){
+    public void setStandardKeyboard(){
+
+        int layout = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getString("layout", "1"));
+
         if(PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("arr_qrt", false) && PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("nbr_qrt", false)){
-            qwertyKeyboardID = R.xml.qwerty_arrow_numbers;
+            switch (layout) {
+                case 2:
+                    standardKeyboardID = R.xml.azerty_arrow_numbers;
+                    break;
+                default:
+                    standardKeyboardID = R.xml.qwerty_arrow_numbers;
+            }
             setRowNumber(5);
         }
         else{
             if(PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("arr_qrt", false)){
-                qwertyKeyboardID = R.xml.qwerty_arrows;
+                switch (layout) {
+                    case 2:
+                        standardKeyboardID = R.xml.azerty_arrows;
+                        break;
+                    default:
+                        standardKeyboardID = R.xml.qwerty_arrows;
+                }
                 setRowNumber(4);
             }
             else if(PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("nbr_qrt", false)){
-                qwertyKeyboardID = R.xml.qwerty_numbers;
+                switch (layout) {
+                    case 2:
+                        standardKeyboardID = R.xml.azerty_numbers;
+                        break;
+                    default:
+                        standardKeyboardID = R.xml.qwerty_numbers;
+                }
                 setRowNumber(5);
             }
             else {
-                qwertyKeyboardID = R.xml.qwerty;
+                switch (layout) {
+                    case 2:
+                        standardKeyboardID = R.xml.azerty;
+                        break;
+                    default:
+                        standardKeyboardID = R.xml.qwerty;
+                }
                 setRowNumber(4);
             }
         }

--- a/app/src/main/java/com/vlath/keyboard/PreferenceFragment.java
+++ b/app/src/main/java/com/vlath/keyboard/PreferenceFragment.java
@@ -13,14 +13,17 @@ public class PreferenceFragment extends android.preference.PreferenceFragment im
 
     ListPreference listTheme;
     ListPreference listStart;
+    ListPreference listLayout;
     @Override
     public void onCreate(Bundle s){
         super.onCreate(s);
         addPreferencesFromResource(R.xml.ime_preferences);
         listTheme = (ListPreference) findPreference("theme");
         listStart = (ListPreference) findPreference("start");
+        listLayout = (ListPreference) findPreference("layout");
         listTheme.setSummary(listTheme.getEntry());
         listStart.setSummary(listStart.getEntry());
+        listLayout.setSummary(listLayout.getEntry());
         PreferenceManager.getDefaultSharedPreferences(getActivity().getBaseContext()).registerOnSharedPreferenceChangeListener(this);
     }
 
@@ -29,5 +32,6 @@ public class PreferenceFragment extends android.preference.PreferenceFragment im
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
         listTheme.setSummary(listTheme.getEntry());
         listStart.setSummary(listStart.getEntry());
+        listLayout.setSummary(listLayout.getEntry());
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,14 +43,23 @@
     </string-array>
 
     <string-array name="start">
-    <item name="1">QWERTY</item>
-    <item name="2">Arrow Keys</item>
-    <item name="3">Programming</item>
+        <item name="1">Standard</item>
+        <item name="2">Arrow Keys</item>
+        <item name="3">Programming</item>
     </string-array>
     <string-array name="start_values">
         <item name="1">1</item>
         <item name="2">2</item>
         <item name="3">3</item>
+    </string-array>
+
+    <string-array name="layout">
+        <item name="1">QWERTY (en-us)</item>
+        <item name="2">AZERTY (fr-fr)</item>
+    </string-array>
+    <string-array name="layout_values">
+        <item name="1">1</item>
+        <item name="2">2</item>
     </string-array>
     <string name="word_separators" translatable="false">\u0020.,;:!?\n()[]*&amp;@{}/&lt;&gt;_+=|&quot;</string>
 </resources>

--- a/app/src/main/res/xml/azerty.xml
+++ b/app/src/main/res/xml/azerty.xml
@@ -1,0 +1,51 @@
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="10%p"
+    android:horizontalGap="0px"
+    android:verticalGap="0px"
+    android:keyHeight="9%p">
+
+    <Row>
+        <Key android:codes="97"  android:keyLabel="a" android:popupKeyboard="@xml/popup_template"  android:popupCharacters="àáâä" android:keyEdgeFlags="left" />
+        <Key android:codes="122" android:keyLabel="z" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="101" android:keyLabel="e" android:popupKeyboard="@xml/popup_template" android:popupCharacters="éèêë" />
+        <Key android:codes="114" android:keyLabel="r" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="116" android:keyLabel="t" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="121" android:keyLabel="y" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ÿ" />
+        <Key android:codes="117" android:keyLabel="u" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ùûü"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupKeyboard="@xml/popup_template" android:popupCharacters="îï"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ôœ" />
+        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right" />
+    </Row>
+    <Row>
+        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" />
+        <Key android:codes="115" android:keyLabel="s" />
+        <Key android:codes="100" android:keyLabel="d" />
+        <Key android:codes="102" android:keyLabel="f" />
+        <Key android:codes="103" android:keyLabel="g" />
+        <Key android:codes="104" android:keyLabel="h" />
+        <Key android:codes="106" android:keyLabel="j" />
+        <Key android:codes="107" android:keyLabel="k" />
+        <Key android:codes="108" android:keyLabel="l" />
+        <Key android:codes="109" android:keyLabel="m" />
+    </Row>
+    <Row>
+        <Key android:codes="-1"  android:keyEdgeFlags="left" android:keyWidth="15%p" android:keyIcon="@drawable/ic_file_upload"/>
+        <Key android:codes="119" android:keyLabel="w" />
+        <Key android:codes="120" android:keyLabel="x" />
+        <Key android:codes="99"  android:keyLabel="c" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ç" />
+        <Key android:codes="118" android:keyLabel="v" />
+        <Key android:codes="98"  android:keyLabel="b" />
+        <Key android:codes="110" android:keyLabel="n" />
+        <Key android:codes="39"  android:keyLabel="\'"/>
+        <Key android:codes="-5"  android:keyWidth="15%p"  android:isRepeatable="true" android:keyIcon="@drawable/ic_backspace" android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:rowEdgeFlags="bottom">
+        <Key android:codes="-2" android:keyLabel="123" android:keyWidth="10%p"/>
+        <Key android:codes="-101" android:keyIcon="@drawable/ic_more_horiz" android:keyWidth="10%p"/>
+        <Key android:codes="44" android:keyLabel="," />
+        <Key android:codes="32"   android:isRepeatable="true" android:keyLabel="ESPACE" android:keyWidth="46.154%p"/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="10"   android:keyWidth="15%p"  android:keyIcon="@drawable/ic_keyboard_return" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/azerty_arrow_numbers.xml
+++ b/app/src/main/res/xml/azerty_arrow_numbers.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="10%p"
+    android:horizontalGap="0px"
+    android:verticalGap="0px"
+    android:keyHeight="9%p">
+
+    <Row>
+        <Key android:codes="49" android:keyLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="50" android:keyLabel="2"/>
+        <Key android:codes="51" android:keyLabel="3"/>
+        <Key android:codes="52" android:keyLabel="4"/>
+        <Key android:codes="53" android:keyLabel="5"/>
+        <Key android:codes="54" android:keyLabel="6"/>
+        <Key android:codes="55" android:keyLabel="7"/>
+        <Key android:codes="56" android:keyLabel="8"/>
+        <Key android:codes="57" android:keyLabel="9"/>
+        <Key android:codes="48" android:keyLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+
+
+    <Row>
+        <Key android:codes="97"  android:keyLabel="a" android:popupKeyboard="@xml/popup_template"  android:popupCharacters="àáâä" android:keyEdgeFlags="left" />
+        <Key android:codes="122" android:keyLabel="z" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="101" android:keyLabel="e" android:popupKeyboard="@xml/popup_template" android:popupCharacters="éèêë" />
+        <Key android:codes="114" android:keyLabel="r" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="116" android:keyLabel="t" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="121" android:keyLabel="y" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ÿ" />
+        <Key android:codes="117" android:keyLabel="u" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ùûü"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupKeyboard="@xml/popup_template" android:popupCharacters="îï"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ôœ" />
+        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right" />
+    </Row>
+    <Row>
+        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" />
+        <Key android:codes="115" android:keyLabel="s" />
+        <Key android:codes="100" android:keyLabel="d" />
+        <Key android:codes="102" android:keyLabel="f" />
+        <Key android:codes="103" android:keyLabel="g" />
+        <Key android:codes="104" android:keyLabel="h" />
+        <Key android:codes="106" android:keyLabel="j" />
+        <Key android:codes="107" android:keyLabel="k" />
+        <Key android:codes="108" android:keyLabel="l" />
+        <Key android:codes="109" android:keyLabel="m" />
+    </Row>
+    <Row>
+        <Key android:codes="-1"  android:keyEdgeFlags="left" android:keyWidth="15%p" android:keyIcon="@drawable/ic_file_upload"/>
+        <Key android:codes="119" android:keyLabel="w" />
+        <Key android:codes="120" android:keyLabel="x" />
+        <Key android:codes="99"  android:keyLabel="c" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ç" />
+        <Key android:codes="118" android:keyLabel="v" />
+        <Key android:codes="98"  android:keyLabel="b" />
+        <Key android:codes="110" android:keyLabel="n" />
+        <Key android:codes="39"  android:keyLabel="\'"/>
+        <Key android:codes="-5"  android:keyWidth="15%p"  android:isRepeatable="true" android:keyIcon="@drawable/ic_backspace" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row android:rowEdgeFlags="bottom">
+        <Key android:codes="-101" android:keyIcon="@drawable/ic_more_horiz" android:keyWidth="10%p"/>
+        <Key android:codes="-2" android:keyLabel="123" android:keyWidth="10%p"/>
+        <Key android:codes="44" android:keyLabel="," />
+        <Key android:codes="-108" android:keyIcon="@drawable/ic_keyboard_arrow_left" android:isRepeatable="true" android:keyWidth="10%p"/>
+        <Key android:codes="32"   android:isRepeatable="true" android:keyLabel="SPACE"
+            android:keyWidth="30%p"/>
+        <Key android:codes="-111" android:keyIcon="@drawable/ic_keyboard_arrow_right" android:isRepeatable="true" android:keyWidth="10%p"/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="10"   android:keyWidth="10%p"  android:keyIcon="@drawable/ic_keyboard_return" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/azerty_arrows.xml
+++ b/app/src/main/res/xml/azerty_arrows.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+        android:keyWidth="10%p"
+        android:horizontalGap="0px"
+        android:verticalGap="0px"
+        android:keyHeight="9%p">
+
+    <Row>
+        <Key android:codes="97"  android:keyLabel="a" android:popupKeyboard="@xml/popup_template"  android:popupCharacters="àáâä" android:keyEdgeFlags="left" />
+        <Key android:codes="122" android:keyLabel="z" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="101" android:keyLabel="e" android:popupKeyboard="@xml/popup_template" android:popupCharacters="éèêë" />
+        <Key android:codes="114" android:keyLabel="r" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="116" android:keyLabel="t" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="121" android:keyLabel="y" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ÿ" />
+        <Key android:codes="117" android:keyLabel="u" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ùûü"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupKeyboard="@xml/popup_template" android:popupCharacters="îï"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ôœ" />
+        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right" />
+    </Row>
+    <Row>
+        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" />
+        <Key android:codes="115" android:keyLabel="s" />
+        <Key android:codes="100" android:keyLabel="d" />
+        <Key android:codes="102" android:keyLabel="f" />
+        <Key android:codes="103" android:keyLabel="g" />
+        <Key android:codes="104" android:keyLabel="h" />
+        <Key android:codes="106" android:keyLabel="j" />
+        <Key android:codes="107" android:keyLabel="k" />
+        <Key android:codes="108" android:keyLabel="l" />
+        <Key android:codes="109" android:keyLabel="m" />
+    </Row>
+    <Row>
+        <Key android:codes="-1"  android:keyEdgeFlags="left" android:keyWidth="15%p" android:keyIcon="@drawable/ic_file_upload"/>
+        <Key android:codes="119" android:keyLabel="w" />
+        <Key android:codes="120" android:keyLabel="x" />
+        <Key android:codes="99"  android:keyLabel="c" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ç" />
+        <Key android:codes="118" android:keyLabel="v" />
+        <Key android:codes="98"  android:keyLabel="b" />
+        <Key android:codes="110" android:keyLabel="n" />
+        <Key android:codes="39"  android:keyLabel="\'"/>
+        <Key android:codes="-5"  android:keyWidth="15%p"  android:isRepeatable="true" android:keyIcon="@drawable/ic_backspace" android:keyEdgeFlags="right"/>
+    </Row>
+        <Row android:rowEdgeFlags="bottom">
+            <Key android:codes="-101" android:keyIcon="@drawable/ic_more_horiz" android:keyWidth="10%p"/>
+            <Key android:codes="-2" android:keyLabel="123" android:keyWidth="10%p"/>
+            <Key android:codes="44" android:keyLabel="," />
+            <Key android:codes="-108" android:keyIcon="@drawable/ic_keyboard_arrow_left" android:isRepeatable="true" android:keyWidth="10%p"/>
+            <Key android:codes="32"   android:isRepeatable="true" android:keyLabel="SPACE"
+                android:keyWidth="30%p"/>
+            <Key android:codes="-111" android:keyIcon="@drawable/ic_keyboard_arrow_right" android:isRepeatable="true" android:keyWidth="10%p"/>
+            <Key android:codes="46" android:keyLabel="."/>
+            <Key android:codes="10"   android:keyWidth="10%p"  android:keyIcon="@drawable/ic_keyboard_return" android:keyEdgeFlags="right"/>
+
+        </Row>
+    </Keyboard>

--- a/app/src/main/res/xml/azerty_numbers.xml
+++ b/app/src/main/res/xml/azerty_numbers.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="10%p"
+    android:horizontalGap="0px"
+    android:verticalGap="0px"
+    android:keyHeight="9%p">
+
+    <Row>
+        <Key android:codes="49" android:keyLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="50" android:keyLabel="2"/>
+        <Key android:codes="51" android:keyLabel="3"/>
+        <Key android:codes="52" android:keyLabel="4"/>
+        <Key android:codes="53" android:keyLabel="5"/>
+        <Key android:codes="54" android:keyLabel="6"/>
+        <Key android:codes="55" android:keyLabel="7"/>
+        <Key android:codes="56" android:keyLabel="8"/>
+        <Key android:codes="57" android:keyLabel="9"/>
+        <Key android:codes="48" android:keyLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="97"  android:keyLabel="a" android:popupKeyboard="@xml/popup_template"  android:popupCharacters="àáâä" android:keyEdgeFlags="left" />
+        <Key android:codes="122" android:keyLabel="z" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="101" android:keyLabel="e" android:popupKeyboard="@xml/popup_template" android:popupCharacters="éèêë" />
+        <Key android:codes="114" android:keyLabel="r" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="116" android:keyLabel="t" android:popupKeyboard="@xml/popup_template" />
+        <Key android:codes="121" android:keyLabel="y" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ÿ" />
+        <Key android:codes="117" android:keyLabel="u" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ùûü"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupKeyboard="@xml/popup_template" android:popupCharacters="îï"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ôœ" />
+        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right" />
+    </Row>
+    <Row>
+        <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left" />
+        <Key android:codes="115" android:keyLabel="s" />
+        <Key android:codes="100" android:keyLabel="d" />
+        <Key android:codes="102" android:keyLabel="f" />
+        <Key android:codes="103" android:keyLabel="g" />
+        <Key android:codes="104" android:keyLabel="h" />
+        <Key android:codes="106" android:keyLabel="j" />
+        <Key android:codes="107" android:keyLabel="k" />
+        <Key android:codes="108" android:keyLabel="l" />
+        <Key android:codes="109" android:keyLabel="m" />
+    </Row>
+    <Row>
+        <Key android:codes="-1"  android:keyEdgeFlags="left" android:keyWidth="15%p" android:keyIcon="@drawable/ic_file_upload"/>
+        <Key android:codes="119" android:keyLabel="w" />
+        <Key android:codes="120" android:keyLabel="x" />
+        <Key android:codes="99"  android:keyLabel="c" android:popupKeyboard="@xml/popup_template" android:popupCharacters="ç" />
+        <Key android:codes="118" android:keyLabel="v" />
+        <Key android:codes="98"  android:keyLabel="b" />
+        <Key android:codes="110" android:keyLabel="n" />
+        <Key android:codes="39"  android:keyLabel="\'"/>
+        <Key android:codes="-5"  android:keyWidth="15%p"  android:isRepeatable="true" android:keyIcon="@drawable/ic_backspace" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row android:rowEdgeFlags="bottom">
+        <Key android:codes="-101" android:keyIcon="@drawable/ic_more_horiz" android:keyWidth="10%p"/>
+        <Key android:codes="-2" android:keyLabel="123" android:keyWidth="10%p"/>
+        <Key android:codes="44" android:keyLabel="," />
+        <Key android:codes="32"   android:isRepeatable="true" android:keyLabel="SPACE"
+            android:keyWidth="46.154%p"/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="10"   android:keyWidth="15%p"  android:keyIcon="@drawable/ic_keyboard_return" android:keyEdgeFlags="right"/>
+
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/ime_preferences.xml
+++ b/app/src/main/res/xml/ime_preferences.xml
@@ -26,6 +26,13 @@
         android:defaultValue="1"
         android:entries="@array/start"/>
 
+    <ListPreference
+        android:title="Layout"
+        android:key="layout"
+        android:entryValues="@array/layout_values"
+        android:defaultValue="1"
+        android:entries="@array/layout"/>
+
     <SwitchPreference android:title="@string/caps"
         android:key="caps"
         android:defaultValue="true" />
@@ -42,11 +49,11 @@
         android:key="pred"
         android:defaultValue="false" />
 
-    <SwitchPreference android:title="Arrow keys on qwerty layout"
+    <SwitchPreference android:title="Arrow keys on standard layout"
         android:key="arr_qrt"
         android:defaultValue="false" />
 
-    <SwitchPreference android:title="Number keys on qwerty layout"
+    <SwitchPreference android:title="Number keys on standard layout"
         android:key="nbr_qrt"
         android:defaultValue="false" />
 


### PR DESCRIPTION
This pull request presents a working version of **behe-keyboard** which support multiple language layouts. The "_qwerty keyboard_" is now called "_standard keyboard_" and a new field in the preferences allow users to chose between multiple layouts (_azerty_ or _qwerty_ for the moment). The way I implemented it, is flexible. It will be easy from now on to add new layouts such as _Dvorak_ or _Bépo_ or any local layout. I am French, so I added the _azerty_ layout (xml file made by @seigneurfuo).